### PR TITLE
Add Jekyll sitemap generator plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,5 @@ collections:
   - docs
 permalink: /:path/:basename/
 baseurl: /worlds-documentation
+plugins:
+  - jekyll-sitemap


### PR DESCRIPTION
Add [sitemap generator plugin](https://github.com/jekyll/jekyll-sitemap).

Exports at build as https://mhcpcreators.github.io/worlds-documentation/sitemap.xml

Signed-off-by: Ben-Scout <ben@scouthouse.com>